### PR TITLE
Undo the layout and components resizing when the side menu is folded/unfolded

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -8,10 +8,9 @@ const Navbar = () => {
   const router = useRouter();
   const pathname = router.pathname.length == 1 && router.pathname == '/' ? router.pathname : router.pathname.substring(1);
   const { state } = useContext(FilterContext);
-  const show_sidebar = state["show_sidebar"];
   return (
     <header className="bg-white text-gray-600 body-font  dark:bg-black  dark:text-white">
-      <div className={show_sidebar == true ? "container ml-64 mx-auto flex flex-wrap p-2 flex-col md:flex-row items-center" : "container mx-auto flex flex-wrap p-2 flex-col md:flex-row items-center"}>
+      <div className="container mx-auto flex flex-wrap p-2 flex-col md:flex-row items-center">
 
         <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-gray-400	flex flex-wrap items-center text-base justify-center">
           <Link href={'/'} as={`/`}>
@@ -31,7 +30,7 @@ const Navbar = () => {
               <span className={pathname == 'about' ? 'text-blue-700 pl-2' : 'pl-2'}>About</span>
             </a>
           </Link>
-        </nav>       
+        </nav>
       </div>
     </header>
   )

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -84,8 +84,6 @@ const Sidebar = () => {
 
           <span className={show_sidebar == true ? 'px-2 text-blue-700' : 'px-2'}>
             Map Filters
-
-
           </span>
         </button>
 
@@ -102,7 +100,7 @@ const Sidebar = () => {
           <div className="absolute -right-10 object-center top-1/2 z-20">
             {
               /**
-               * 
+               *
                *   <SidebarExternalMenu />
                */
             }
@@ -217,7 +215,7 @@ const Sidebar = () => {
                                       <li ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
 
                                         <div className="flex i items-center"
-                                        
+
                                         onClick={() => {
                                           const newItems = [...socioeconomicStatus2.data];
                                           newItems[index] = {
@@ -231,7 +229,7 @@ const Sidebar = () => {
                                           dispatch({ type: "CHANGE_SOCIOECONOMIC", payload: newItems })
                                           // setSocioEconomicLayers(newItems);
                                         }}
-                                        
+
                                         >
                                           <input className="ml-5 bg-gray-50 border-gray-300 focus:ring-3 focus:ring-blue-300 h-4 w-4 rounded" id="flowbite" aria-describedby="flowbite" type="checkbox"
                                             checked={val.status}
@@ -290,7 +288,7 @@ focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none
                                                         // setSocioEconomicLayers(newItems);
                                                       }}
                                                       className=" form-range h-6 p-0focus:outline-none focus:ring-0 focus:shadow-none"
-                                                      
+
                                                       />
 
                                                   </div>
@@ -398,7 +396,7 @@ focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none
                                                 <li className="relative" ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
 
                                                   <div className="flex i items-center"
-                                                  
+
                                                   onClick={() => {
                                                     const newItems = [...geodata.data];
                                                     newItems[index]['data'][index2] = {
@@ -412,7 +410,7 @@ focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none
                                                     dispatch({ type: "CHANGE_GEODATA", payload: newItems })
 
                                                   }}
-                                                  
+
                                                   >
                                                     <input className="ml-5 bg-gray-50 border-gray-300 focus:ring-3 focus:ring-blue-300 h-4 w-4 rounded" id="flowbite" aria-describedby="flowbite" type="checkbox"
 

--- a/components/Topbar.js
+++ b/components/Topbar.js
@@ -5,10 +5,9 @@ import circular_logo from '/public/images/logo512.png'
 import undp_logo from '/public/images/UNDP_Logo.png'
 const TopBar = () => {
     const { state } = useContext(FilterContext);
-    const show_sidebar = state["show_sidebar"];
     return (
         <header className="bg-white text-gray-600 body-font ">
-            <div className={show_sidebar == true ? 'container ml-64 mx-auto flex flex-wrap px-5 flex-col md:flex-row items-center' : 'container ml-auto mx-auto flex flex-wrap px-5 flex-col md:flex-row items-center'}>
+            <div className="container ml-auto mx-auto flex flex-wrap px-5 flex-col md:flex-row items-center">
                 <a className="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
                     <span className="ml-3 text-xl">DSVI Tajikistan Development Tool</span>
                 </a>

--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -2,18 +2,17 @@ import { useContext } from 'react';
 import Image from "next/image";
 import sdglogo from '/public/images/sdglogodark.jpg'
 import undp_logo from '/public/images/UNDP_Logo.png'
-import { FilterContext } from '../../context/FilterContext' 
+import { FilterContext } from '../../context/FilterContext'
 
 const Footer = () => {
 
   const { state } = useContext(FilterContext);
-  const show_sidebar = state["show_sidebar"];
 
   return (
     <>
 
       <footer className="bg-white text-gray-600 body-font">
-        <div className={show_sidebar == true ? "container px-5 py-2 ml-64 mx-auto flex items-center sm:flex-row flex-col" : "container px-5 py-2 mx-auto flex items-center sm:flex-row flex-col" }>
+        <div className="container px-5 py-2 mx-auto flex items-center sm:flex-row flex-col">
           <a className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">
 
           <Image
@@ -25,7 +24,7 @@ const Footer = () => {
                       className="h-12"
                     />
 
-         
+
             <span className="ml-3 text-xl">DSVI Tajikistan Development Tool</span>
           </a>
           <p className="text-sm text-gray-500 sm:ml-4 sm:pl-4 sm:border-l-2 sm:border-gray-200 sm:py-2 sm:mt-0 mt-4">© 2022 —
@@ -34,7 +33,7 @@ const Footer = () => {
 
 
           <span className="flex justify-center self-center items-center text-center  mx-auto">
-      
+
             <Image
                         src={undp_logo}
                         alt="undp logo"

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,12 +8,11 @@ const OsmMapNoSSR =dynamic(()=>import("../components/mapbox/Map"),{
 })
 const Map1=()=>{
     const { state} = useContext(FilterContext);
-    const show_sidebar = state["show_sidebar"];
-    const [location,setLocation]=useState({lng:42.883084,lat:70.921398})   
+    const [location,setLocation]=useState({lng:42.883084,lat:70.921398})
     return(
-        <>        
+        <>
             <Sidebar/>
-            <div className={show_sidebar==true?'ml-64 m-10  p-5 bg-white rounded-lg w-[80rem]':'m-10 p-5 bg-white rounded-lg'}>
+            <div className="m-10 p-5 bg-white rounded-lg" >
             <OsmMapNoSSR
                 center={location}
                 location={location}
@@ -23,7 +22,7 @@ const Map1=()=>{
                     let loc= {lat: e.lat, lng:e.lng};
                     setLocation(loc);
                 }}
-            />                
+            />
             </div>
             <DataSidebar/>
         </>


### PR DESCRIPTION
![chrome-capture-2022-5-22](https://user-images.githubusercontent.com/5660582/175041155-540d5d9f-ae7a-4b82-a741-6c7f11afb454.gif)

This removes the layout (map, top bar, nav bar, footer) from resizing when the side menu is folded/unfolded. The layout resizing did not match with the folding/unfolding animation.

Took inspiration from the way Google Maps behaves:

![chrome-capture-2022-5-22 (1)](https://user-images.githubusercontent.com/5660582/175041374-4cc21c83-8580-4554-8af9-5292239abf66.gif)
