### PR TITLE
Add instructions to install dependencies using yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Code base seated on repo  [UNDP DSVI Tool]([](https://github.com/SDG-AI-Lab/DSVI
 
 In the project directory, you can run:
 
-### `npm run dev`
+### `yarn install`
+
+Install dependencies.
+
+### `yarn run dev`
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.


### PR DESCRIPTION
Update the README.md to describe how to install the dependencies.

Also update the instruction to run the dev server using yarn, since this seems to be the chosen package manager (over npm), and the package-lock.json is out of sync with yarn.lock.