### PR TITLE
infobox now has a how to tab

### DIFF
--- a/components/controls/InfoBox.js
+++ b/components/controls/InfoBox.js
@@ -98,7 +98,12 @@ const infoBoxRef = useRef();
 
 // the tabs inside the infoBox: Social vulnerability, Data Exploration, Methods, and How to use
 const Tabs = (props) => {
-  const [openTab, setOpenTab] = useState(1);
+  const [openTab, setOpenTab] = useState(4);
+
+  useEffect(() => {
+      setOpenTab(2);
+  }, [InfoBox])
+
   return (
     <>
       {/* tabs */}
@@ -333,7 +338,25 @@ const Tabs = (props) => {
       </div>
 
       <div className={`${openTab === 2 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
-        <InfoDiv setTab={setOpenTab}dropdownValue={props.dropdownValue} dropdownDescIndex={props.dropdownDescIndex} changingDropdown={props.changingDropdown}/>
+        {/* <InfoDiv setTab={setOpenTab} dropdownValue={props.dropdownValue} dropdownDescIndex={props.dropdownDescIndex} changingDropdown={props.changingDropdown}/> */}
+        <Dropdown menuClassName='max-w-11/12 left-4p rounded-xl h-50' 
+          controlClassName='rounded-xl w-11/12 m-auto' options={dropDownOptions} 
+          onChange={(e) => props.changingDropdown(e.value)} 
+          value={props.dropdownValue} 
+          placeholder="Select an option" />
+        <div className='max-w-md px-4 mt-5 square'>
+          {/* <h2 className='font-bold'>{dropDownDescriptions[dropdownDescIndex].heading}</h2> */}
+          {/* <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[dropdownDescIndex].desc}</p> */}
+          <div>
+            {dropDownDescriptions[props.dropdownDescIndex].img && 
+            <img
+              style={{ width: '100px' }}
+              src={dropDownDescriptions[props.dropdownDescIndex].img}
+              alt="poverty"
+            /> }
+          </div>  
+          <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[props.dropdownDescIndex].desc}</p>
+        </div>  
       </div>
 
       <div className={`${openTab === 3 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
@@ -354,7 +377,9 @@ const InfoDiv = (props) => {
     <>
       <Dropdown menuClassName='max-w-11/12 left-4p rounded-xl h-50' 
           controlClassName='rounded-xl w-11/12 m-auto' options={dropDownOptions} 
-          onChange={(e) => {props.setTab(2); props.changingDropdown(e.value)}} value={props.dropdownValue} 
+          onChange={(e) => props.changingDropdown(e.value)} 
+          onClick={props.setTab(2)}
+          value={props.dropdownValue} 
           placeholder="Select an option" />
         <div className='max-w-md px-4 mt-5 square'>
           {/* <h2 className='font-bold'>{dropDownDescriptions[dropdownDescIndex].heading}</h2> */}

--- a/components/controls/InfoBox.js
+++ b/components/controls/InfoBox.js
@@ -10,15 +10,13 @@ import L from 'leaflet';
 
 // options for the drop down menu in infoBox
 const dropDownOptions = [
-  'Social Vulnerability', 'SV Prediction: Random Forest', 'SV: Prediction: XGBoost', 'Accessibility: Education Facility', 'Accessibility: Health Institution', 'Accessibility: Financial Service',
+  'SV Prediction: Random Forest', 'SV: Prediction: XGBoost', 'Accessibility: Education Facility', 'Accessibility: Health Institution', 'Accessibility: Financial Service',
   'Population Counts', 'Celltowers', 'Nightlight Intensity', 'Relative Wealth', 'GDP', 'Plant Health', 'Temperature (Max)',
   'Land Use Class', 'Elevation'
 ]
 
 // each index for the above list has a description in the list below which is shown in infoBox
 const dropDownDescriptions = [
-  {heading: 'Social Vulnerability Platform', 
-  desc: 'Social Vulnerability (SV) is the capacity of individuals or communities to cope with social and environmental shocks   (Adger 2000, Cutter 2003). This includes climate change, natural disasters, and other societal risks. Vulnerable groups have a disproportionate risk of being affected and experiencing more profound consequences, due to their socio-economic preconditions. SV assessments help to better map the connection between local conditions, social characteristics, or individual vulnerabilities and risks. The calculation of SV scores is a frequent practice to measure a community’s ability to respond to outside stressors and risks. It is an indirect way to quantify resilience. Having such an assessment helps to understand, get prepared and respond in a more effective manner, using a combination of the most appropriate tools once the risk materializes.'},
   {heading: 'SV Prediction: Random Forest', desc: 'This layer is a prediction of Social Vulnerability with sklearns Random Forest Regressor. A random forest is a meta estimator that fits a number of classifying decision trees on various sub-samples of the dataset and uses averaging to improve the predictive accuracy and control over-fitting. The sub-sample size is controlled with the max_samples parameter if bootstrap=True (default), otherwise the whole dataset is used to build each tree.'},
   {heading: 'SV: Prediction: XGBoost', desc: 'This algorithm builds an additive model in a forward stage-wise fashion; it allows for the optimization of arbitrary differentiable loss functions. In each stage n_classes_ regression trees are fit on the negative gradient of the loss function, e.g. binary or multiclass log loss. Binary classification is a special case where only a single regression tree is induced.'},
   {heading: 'Accessibility: Education Facility', desc: 'This layer shows the time it takes to drive an individual to the next available Education Facility. The data was provided by OpenStreetMap. The download source is humdata.org'},
@@ -51,7 +49,6 @@ const InfoBox = (props) => {
   }
 
 const infoBoxRef = useRef();
-
   useEffect(() => {
     if (infoBoxRef.current) {
       /*Using the wheel will not change the zoom on the map.*/
@@ -89,43 +86,24 @@ const infoBoxRef = useRef();
             <button className="button-infoBox" onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();
-
               dispatch({ type: "TOGGLE_INFOBOX_DATA", payload: {} })
             }}>x</button>
-            <Tabs />
-            <Dropdown menuClassName='max-w-11/12 left-4p rounded-xl h-50' 
-              controlClassName='rounded-xl w-11/12 m-auto' options={dropDownOptions} 
-              onChange={(e) => changingDropdown(e.value)} value={dropdownValue} 
-              placeholder="Select an option" />
-            <div className='max-w-md px-4 mt-5 square'>
-              {/* <h2 className='font-bold'>{dropDownDescriptions[dropdownDescIndex].heading}</h2> */}
-              {/* <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[dropdownDescIndex].desc}</p> */}
-              <div>
-                {dropDownDescriptions[dropdownDescIndex].img && <img
-                  style={{ width: '100px' }}
-                  src={dropDownDescriptions[dropdownDescIndex].img}
-                  alt="poverty"
-                /> }
-              </div>  
-              <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[dropdownDescIndex].desc}</p>
+            <Tabs dropdownValue={dropdownValue} dropdownDescIndex={dropdownDescIndex} changingDropdown={changingDropdown}/>  
           </div>
-        </div>
-
         : null }
         </div>
       </Control>
   )
 }
 
-// the tabs inside the infoBox: Social vulnerability, Data Exploration, and Methods
-
-const Tabs = () => {
+// the tabs inside the infoBox: Social vulnerability, Data Exploration, Methods, and How to use
+const Tabs = (props) => {
   const [openTab, setOpenTab] = useState(1);
   return (
-    
     <>
-   
+      {/* tabs */}
       <div className="flex items-start mb-3">
+        {/* the different options available inside InfoBox */}
         <ul
           className="nav nav-tabs mr-1 flex list-none flex-col flex-wrap border-b-0 pl-0"
           role="tablist"
@@ -162,8 +140,8 @@ const Tabs = () => {
                 'block rounded px-5 py-1 text-base leading-normal text-black '
               }
               onClick={(e) => {
-                e.preventDefault()
-                setOpenTab(2)
+                e.preventDefault();
+                setOpenTab(2);
               }}
               data-toggle="tab"
               href="#link2"
@@ -193,7 +171,30 @@ const Tabs = () => {
               Methods
             </a>
           </li>
+          <li
+            className="nav-item flex-grow text-left"
+            style={{
+              background: openTab === 4 ? '#e6f9ff' : 'transparent',
+            }}
+          >
+            <a
+              className={
+                'block rounded px-5 py-1 text-base leading-normal text-black'
+              }
+              onClick={(e) => {
+                e.preventDefault()
+                setOpenTab(4)
+              }}
+              data-toggle="tab"
+              href="#link4"
+              role="tablist"
+            >
+              How to use
+            </a>
+          </li>
         </ul>
+
+        {/* each option/tab's respective image div */}
         <div className="tab-content">
           <div className="flex-auto ml-20">
             <div
@@ -301,10 +302,75 @@ const Tabs = () => {
                 />
               </Carousel>
             </div>
+
+            <div
+              className={`${openTab === 4 ? 'block' : 'hidden'
+              } tab-pane fade show active`}
+              style={{ width: '150px' }}
+              id="link4"
+            >
+              <Carousel
+                className="info_carousel"
+                showArrows={false}
+                showIndicators={false}
+                showThumbs={false}
+                showStatus={false}
+              >
+                <img
+                  style={{ width: '100px' }}
+                  src="https://knowsdgs.jrc.ec.europa.eu/themes/sdgs/assets/img/sdg1.png"
+                  alt="poverty"
+                />
+              </Carousel>
+            </div>
           </div>
         </div>
       </div>
+
+      {/* each tab's information area */}
+      <div className={`${openTab === 1 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
+        Social Vulnerability (SV) is the capacity of individuals or communities to cope with social and environmental shocks   (Adger 2000, Cutter 2003). This includes climate change, natural disasters, and other societal risks. Vulnerable groups have a disproportionate risk of being affected and experiencing more profound consequences, due to their socio-economic preconditions. SV assessments help to better map the connection between local conditions, social characteristics, or individual vulnerabilities and risks. The calculation of SV scores is a frequent practice to measure a community’s ability to respond to outside stressors and risks. It is an indirect way to quantify resilience. Having such an assessment helps to understand, get prepared and respond in a more effective manner, using a combination of the most appropriate tools once the risk materializes.
+      </div>
+
+      <div className={`${openTab === 2 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
+        <InfoDiv setTab={setOpenTab}dropdownValue={props.dropdownValue} dropdownDescIndex={props.dropdownDescIndex} changingDropdown={props.changingDropdown}/>
+      </div>
+
+      <div className={`${openTab === 3 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
+        No method details yet.
+      </div>
+      <div className={`${openTab === 4 ? 'block' : 'hidden'} my-3 leading-relaxed mb-3 text-justify max-w-md px-4 mt-5 square`}>
+        <h1 className='text-xl font-semibold leading-10'>Welcome to the DSVI Tool</h1>
+        Shift + drawing a box with your mouse will allow you to zoom into the area on the map.
+      </div>
+      {/* <InfoDiv dropdownValue={props.dropdownValue} dropdownDescIndex={props.dropdownDescIndex} changingDropdown={props.changingDropdown}/> */}
+      
     </>
+  )
+};
+
+const InfoDiv = (props) => {
+  return (
+    <>
+      <Dropdown menuClassName='max-w-11/12 left-4p rounded-xl h-50' 
+          controlClassName='rounded-xl w-11/12 m-auto' options={dropDownOptions} 
+          onChange={(e) => {props.setTab(2); props.changingDropdown(e.value)}} value={props.dropdownValue} 
+          placeholder="Select an option" />
+        <div className='max-w-md px-4 mt-5 square'>
+          {/* <h2 className='font-bold'>{dropDownDescriptions[dropdownDescIndex].heading}</h2> */}
+          {/* <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[dropdownDescIndex].desc}</p> */}
+          <div>
+            {dropDownDescriptions[props.dropdownDescIndex].img && 
+            <img
+              style={{ width: '100px' }}
+              src={dropDownDescriptions[props.dropdownDescIndex].img}
+              alt="poverty"
+            /> }
+          </div>  
+          <p className='my-3 leading-relaxed mb-3 text-justify'>{dropDownDescriptions[props.dropdownDescIndex].desc}</p>
+        </div>
+    </>
+    
   )
 };
 export default InfoBox;

--- a/components/controls/InfoBox.js
+++ b/components/controls/InfoBox.js
@@ -100,10 +100,6 @@ const infoBoxRef = useRef();
 const Tabs = (props) => {
   const [openTab, setOpenTab] = useState(4);
 
-  useEffect(() => {
-      setOpenTab(2);
-  }, [InfoBox])
-
   return (
     <>
       {/* tabs */}
@@ -341,7 +337,7 @@ const Tabs = (props) => {
         {/* <InfoDiv setTab={setOpenTab} dropdownValue={props.dropdownValue} dropdownDescIndex={props.dropdownDescIndex} changingDropdown={props.changingDropdown}/> */}
         <Dropdown menuClassName='max-w-11/12 left-4p rounded-xl h-50' 
           controlClassName='rounded-xl w-11/12 m-auto' options={dropDownOptions} 
-          onChange={(e) => props.changingDropdown(e.value)} 
+          onClick={(e) => props.changingDropdown(e.value)} 
           value={props.dropdownValue} 
           placeholder="Select an option" />
         <div className='max-w-md px-4 mt-5 square'>


### PR DESCRIPTION
The basic functionality is done for the infobox. 
- It has a 'how to' tab
- dropdown menu is only shown for data exploration now

There was an old issue that when a dropdown option is selected, the openTab state would be set to default (1) and it would open the social vulnerability tab again. This wasn't noticeable (I guess) when the dropdown existed for all tabs.
Now when a user selects the dropdown in Data exploration, it goes to Social Vulnerability again (state reset).
This problem hasn't been fixed yet. 
Shown below:

https://user-images.githubusercontent.com/73817977/203389430-2a3a5b00-b9a3-4eca-9498-53cce3f3d6f8.mp4



